### PR TITLE
Remove HTTParty Dependency

### DIFF
--- a/gpsoauth.gemspec
+++ b/gpsoauth.gemspec
@@ -24,6 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.9.0"
   spec.add_development_dependency "byebug", "~> 9.0.5"
-
-  spec.add_dependency "httparty", "~> 0.14"
 end

--- a/lib/gpsoauth.rb
+++ b/lib/gpsoauth.rb
@@ -1,12 +1,13 @@
-require "httparty"
 require "base64"
+require 'json'
+require 'net/http'
+require 'net/https'
 
-require "gpsoauth/client"
-require "gpsoauth/exceptions"
-require "gpsoauth/google"
-require "gpsoauth/version"
+require_relative "gpsoauth/client"
+require_relative "gpsoauth/exceptions"
+require_relative "gpsoauth/google"
+require_relative "gpsoauth/version"
 
 module Gpsoauth
-  include HTTParty
   include Google
 end

--- a/lib/gpsoauth/client.rb
+++ b/lib/gpsoauth/client.rb
@@ -21,6 +21,15 @@ module Gpsoauth
       @sdk_version = sdk_version || 17
     end
 
+    def use_proxy(host, port, login = nil, password = nil)
+      @proxy_host = host
+      @proxy_port = port
+      @proxy_login = login
+      @proxy_password = password
+
+      return self
+    end
+
     def master_login(email, password)
       android_key = Google::key_from_b64(B64_KEY_7_3_29)
 
@@ -68,7 +77,11 @@ module Gpsoauth
       uri = URI(AUTH_URL)
 
       # Create client
-      http = Net::HTTP.new(uri.host, uri.port)
+      if @proxy_host && @proxy_port
+        http = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
+      else
+        http = Net::HTTP.new(uri.host, uri.port)
+      end
       #http.set_debug_output $stdout
       http.use_ssl = true
       http.verify_mode = ::OpenSSL::SSL::VERIFY_NONE

--- a/lib/gpsoauth/client.rb
+++ b/lib/gpsoauth/client.rb
@@ -78,7 +78,7 @@ module Gpsoauth
 
       # Create client
       if @proxy_host && @proxy_port
-        http = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
+        http = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_login, @proxy_password)
       else
         http = Net::HTTP.new(uri.host, uri.port)
       end

--- a/lib/gpsoauth/client.rb
+++ b/lib/gpsoauth/client.rb
@@ -47,7 +47,7 @@ module Gpsoauth
         accountType: "HOSTED_OR_GOOGLE",
         Email: email,
         has_permission: 1,
-        EncryptedPasswd: master_token,
+        Token: master_token,
         source: "android",
         androidId: @android_id,
         device_country:  @device_country,
@@ -65,16 +65,30 @@ module Gpsoauth
     private
 
     def auth_request(data)
-      options = {
-        body: data,
-        headers: {
-          "User-Agent" => USER_AGENT,
-          "Accept-Encoding" => ""
-        }
-      }
+      uri = URI(AUTH_URL)
 
-      response = HTTParty.post(AUTH_URL, options)
-      parse_auth_response(response)
+      # Create client
+      http = Net::HTTP.new(uri.host, uri.port)
+      #http.set_debug_output $stdout
+      http.use_ssl = true
+      http.verify_mode = ::OpenSSL::SSL::VERIFY_NONE
+      body = URI.encode_www_form(data)
+
+      # Create Request
+      req =  Net::HTTP::Post.new(uri)
+      # Add headers
+      req.add_field "User-Agent", USER_AGENT
+      # Add headers
+      req.add_field "Accept-Encoding", ""
+      # Add headers
+      #req.add_field "Content-Type", "application/json"
+      # Set body
+      req.body = body
+
+      # Fetch Request
+      res = http.request(req)
+
+      parse_auth_response(res.body)
     end
 
     def parse_auth_response(response)

--- a/lib/gpsoauth/version.rb
+++ b/lib/gpsoauth/version.rb
@@ -1,3 +1,3 @@
 module Gpsoauth
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/lib/gpsoauth/version.rb
+++ b/lib/gpsoauth/version.rb
@@ -1,3 +1,3 @@
 module Gpsoauth
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
By removing HTTParty, and using Net:HTTP the gem is

- Easier to read and test
- Lighter, since it does not introduce any additional dependency
- Faster, since HTTParty uses Net:HTTP under the hood
- More portable, since Net:HTTP is part of the standard library

